### PR TITLE
Added past member code, and added lots of past members info.

### DIFF
--- a/_data/past_members.yml
+++ b/_data/past_members.yml
@@ -1,7 +1,139 @@
-- name: Tom Le Paine
-  title: Captain McAwesome
-  image: stamos.jpeg
+- name: Ashutosh Garg
+  job: Bloomreach Inc.
+  email: ashutosh@ifp.uiuc.edu
+  url: http://www.ifp.illinois.edu/~ashutosh/
 
-- name: Pooya Khorrami
-  title: Commander Jedi Awesome
-  image: clooney.jpeg
+- name: Chang Wen Chen
+  job: Unversity of Buffalo
+  email: chencw@cse.buffalo.edu
+  url: http://www.cse.buffalo.edu/UBMM/People/dr.chen.html
+
+- name: Xinqi Chu
+  job: 
+  email: 
+  url: http://www.ifp.illinois.edu/~chu36/index.html
+
+- name: Guo-Jun Qi
+  job: University of Central Florida
+  email: guojunq@gmail.com
+  url: http://www.eecs.ucf.edu/~gqi/
+
+- name: Haichao Zhang
+  job: Amazon
+  email: hczhang1@gmail.com
+  url: https://sites.google.com/site/hczhang1/home
+
+- name: Hanning Zhou
+  job: Amazon
+  email: hzhou@ifp.uiuc.edu
+  url: http://www.ifp.illinois.edu/~hzhou/
+
+- name: Henry Hao Tang
+  job: 
+  email: haotang2@uiuc.edu
+  url: http://www.ifp.illinois.edu/~haotang2/index.html
+
+- name: Huazhong Ning
+  job: Google
+  email: ninghz@gmail.com
+  url: http://www.ifp.illinois.edu/~hning2/
+
+- name: Jianchao Yang
+  job: Adobe 
+  email: jiayang@adobe.com
+  url: http://www.ifp.illinois.edu/~jyang29/
+
+- name: Jiebo Luo
+  job: Unversity of Rochester
+  email: jluo@cs.rochester.edu
+  url: http://www.cs.rochester.edu/u/jluo/
+
+- name: Jilin Tu
+  job: General Electric
+  email: 
+  url: http://www.ifp.illinois.edu/~jilintu/
+
+- name: John Lin
+  job: 
+  email: jylin9@ifp.uiuc.edu
+  url: http://www.ifp.illinois.edu/~jy-lin/
+
+- name: Liangliang Cao
+  job: IBM 
+  email: liangliang.cao@gmail.com
+  url: http://www.ifp.illinois.edu/~cao4/
+
+- name: Ming Liu
+  job: 
+  email: mingliu1@ifp.uiuc.edu
+  url: http://www.ifp.illinois.edu/~mingliu1/
+
+- name: Nebojsa Jojic
+  job: Microsoft
+  email: jojic@microsoft.com
+  url: http://research.microsoft.com/en-us/um/people/jojic/
+
+- name: Nemanja Petrovic
+  job: Google
+  email: 
+  url: http://www.ifp.illinois.edu/~nemanja/resume.html
+
+- name: Ying Wu
+  job: Northwestern
+  email: yingwu@northwestern.edu
+  url: http://users.eecs.northwestern.edu/~yingwu/
+
+- name: Qi Tian
+  job: University of Texas at San Antonio 
+  email: qitian@cs.utsa.edu
+  url: http://www.cs.utsa.edu/~qitian/
+
+- name: Qiong Liu
+  job: FXPAL
+  email: liu@fxpal.com
+  url: http://www.fxpal.com/people/qiong-liu
+
+- name: Zhaowen Wang
+  job: Adobe
+  email: 
+  url: http://www.ifp.illinois.edu/~wang308/
+
+- name: Terrence Chen
+  job: Siemens
+  email: 
+  url: http://www.ifp.illinois.edu/~tchen5/AboutMe.html
+
+- name: Tony Xu Han
+  job: Unversity of Missouri-Columbia
+  email: hantx@missouri.edu
+  url: http://web.missouri.edu/~hantx/
+
+- name: Vuong Le
+  job: Amazon
+  email: 
+  url: http://www.ifp.illinois.edu/~vuongle2/
+
+- name: Xiang Sean Zhou
+  job: 
+  email: 
+  url: http://www.ifp.illinois.edu/~xzhou2/
+
+- name: Yue Zhou
+  job: 
+  email: yuezhou@ifp.uiuc.edu
+  url: http://www.ifp.illinois.edu/~yuezhou/
+
+- name: Yunqiang Chen
+  job: 
+  email: 
+  url: http://www.ifp.illinois.edu/~chenyq/
+
+- name: Yuxiao Hu
+  job: Microsoft
+  email: yuxiaohu@msn.com
+  url: http://www.ifp.illinois.edu/~hu3/
+
+- name: Zhen Li
+  job: Google
+  email: 
+  url:

--- a/_includes/members.html
+++ b/_includes/members.html
@@ -2,7 +2,9 @@
     <div class="row centered">
         <h3 class="mb">Current Students</h3>
         
-        {% for member in site.data.members %}
+        {% assign sorted_members = site.data.members | sort:"name" %}
+
+        {% for member in sorted_members %}
         <div class="col-lg-3 col-md-3 col-sm-3">
             <div class="he-wrap tpl6">
             <img src="{{ "/assets/img/members/" | prepend: site.baseurl }}{{ member.image }}" alt="">

--- a/_includes/past_members.html
+++ b/_includes/past_members.html
@@ -1,0 +1,21 @@
+<div class="container mtb">
+    <div class="row centered">
+        <h3 class="mb">Past Students</h3>
+        
+        {% for member in site.data.past_members %}
+            <p>
+            {% if member.url %}
+               <a href="{{ member.url }}">{{ member.name }}</a>
+            {% else %}
+                {{ member.name }}
+            {% endif %}
+
+            {% if member.job %}
+              - {{ member.job }}
+            {% endif %}
+            </p>
+            
+        {% endfor %}
+        
+    </div><! --/row -->
+</div><! --/container -->

--- a/_includes/past_members.html
+++ b/_includes/past_members.html
@@ -2,7 +2,9 @@
     <div class="row centered">
         <h3 class="mb">Past Students</h3>
         
-        {% for member in site.data.past_members %}
+        {% assign sorted_members = site.data.past_members | sort:"name" %}
+
+        {% for member in sorted_members %}
             <p>
             {% if member.url %}
                <a href="{{ member.url }}">{{ member.name }}</a>

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -6,3 +6,5 @@ layout: default
 	{{ content }}
 
 {% include members.html %}
+
+{% include past_members.html %}


### PR DESCRIPTION
@pkhorrami4 
# Running it

I think if you `git pull origin`, you will get the `add-past-members` branch. And then you can checkout that branch, and then view the changes in a browser using `jekyll serve`. Did you do that before? I think it will work?
# What is here

The current pull request has a working past members section, and about 25 members info. But their info is in random order.
# Todos

I think it would be better if I sorted... preferably by first name. What do you think? I think we can do this using Liquid template filters... but I am not sure how. If you figure out how, I think you can add the code to your local copy of `add-past-member`, and push it, and it will get added to the pull request! Pair coding at a distance! **Woot!**
